### PR TITLE
Map source url fragment to path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is a modest attempt at providing a simplistic yet opinionated Elm [SPA](htt
 ## Features
 
 - Elm 0.19 ready
-- Multiple pages navigation & routing
+- Multiple pages navigation & routing, based on URL fragments
 - Live development server with hot reloading
 - [elm-test](https://github.com/elm-community/elm-test) support
 - JavaScript build minification using UglifyJS.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-kitchen",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "An utility to generate an Elm SPA skeleton.",
   "bin": {
     "elm-kitchen": "index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-kitchen",
-  "version": "5.0.0",
+  "version": "4.0.0",
   "description": "An utility to generate an Elm SPA skeleton.",
   "bin": {
     "elm-kitchen": "index.js"

--- a/skeleton/package.json
+++ b/skeleton/package.json
@@ -18,13 +18,13 @@
     "params": "pure_funcs=\"F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9\",pure_getters,keep_fargs=false,unsafe_comps,unsafe"
   },
   "devDependencies": {
-    "elm": "^0.19.0-bugfix6",
+    "elm": "^0.19.0-no-deps",
     "elm-format": "^0.8.1",
-    "elm-live": "^3.4.0",
+    "elm-live": "^3.4.1",
     "elm-test": "^0.19.0-rev6",
     "gh-pages": "^2.0.1",
     "npm-run-all": "^4.1.5",
-    "rimraf": "^2.6.1",
-    "uglify-js": "^3.4.9"
+    "rimraf": "^2.6.3",
+    "uglify-js": "^3.5.15"
   }
 }

--- a/skeleton/src/Main.elm
+++ b/skeleton/src/Main.elm
@@ -4,8 +4,6 @@ import Browser exposing (Document)
 import Browser.Navigation as Nav
 import Data.Session as Session exposing (Session)
 import Html exposing (..)
-import Json.Decode as Decode
-import Json.Encode as Encode
 import Page.Counter as Counter
 import Page.Home as Home
 import Ports

--- a/skeleton/src/Page/Counter.elm
+++ b/skeleton/src/Page/Counter.elm
@@ -1,9 +1,8 @@
 module Page.Counter exposing (Model, Msg, init, update, view)
 
-import Data.Session as Session exposing (Session)
+import Data.Session exposing (Session)
 import Html exposing (..)
 import Html.Events exposing (onClick)
-import Ports
 import Route
 
 

--- a/skeleton/src/Page/Home.elm
+++ b/skeleton/src/Page/Home.elm
@@ -1,12 +1,10 @@
 module Page.Home exposing (Model, Msg(..), init, update, view)
 
-import Browser exposing (Document)
 import Data.Session exposing (Session)
 import Html exposing (..)
 import Http
 import Markdown
 import Request.Github as Github
-import Task
 
 
 type alias Model =

--- a/skeleton/src/Ports.elm
+++ b/skeleton/src/Ports.elm
@@ -1,7 +1,5 @@
 port module Ports exposing (saveStore, storeChanged)
 
-import Json.Encode as Encode
-
 
 port saveStore : String -> Cmd msg
 

--- a/skeleton/src/Request/Github.elm
+++ b/skeleton/src/Request/Github.elm
@@ -1,5 +1,6 @@
 module Request.Github exposing (errorToString, getReadme)
 
+import Data.Session exposing (Session)
 import Http exposing (Error(..))
 
 

--- a/skeleton/src/Request/Github.elm
+++ b/skeleton/src/Request/Github.elm
@@ -1,6 +1,5 @@
 module Request.Github exposing (errorToString, getReadme)
 
-import Data.Session exposing (Session)
 import Http exposing (Error(..))
 
 
@@ -24,7 +23,7 @@ errorToString error =
 
 
 getReadme : Session -> (Result Error String -> msg) -> Cmd msg
-getReadme session event =
+getReadme _ event =
     Http.get
         { url = "README.md"
         , expect = Http.expectString event

--- a/skeleton/src/Route.elm
+++ b/skeleton/src/Route.elm
@@ -1,11 +1,10 @@
 module Route exposing (Route(..), fromUrl, href, pushUrl)
 
-import Browser exposing (Document)
 import Browser.Navigation as Nav
 import Html exposing (Attribute)
 import Html.Attributes as Attr
 import Url exposing (Url)
-import Url.Parser as Parser exposing ((</>), Parser)
+import Url.Parser as Parser exposing (Parser)
 
 
 type Route
@@ -21,9 +20,32 @@ parser =
         ]
 
 
+{-| Note: as elm-kitchen relies on URL fragment based routing, the source URL is
+updated so that the `fragment` part becomes the `path` one.
+-}
 fromUrl : Url -> Maybe Route
 fromUrl url =
-    { url | path = Maybe.withDefault "" url.fragment, fragment = Nothing }
+    let
+        protocol =
+            if url.protocol == Url.Https then
+                "https"
+
+            else
+                "http"
+
+        port_ =
+            case url.port_ of
+                Just p ->
+                    ":" ++ String.fromInt p
+
+                Nothing ->
+                    ""
+
+        path =
+            Maybe.withDefault "/" url.fragment
+    in
+    Url.fromString (protocol ++ "://" ++ url.host ++ port_ ++ path)
+        |> Maybe.withDefault url
         |> Parser.parse parser
 
 


### PR DESCRIPTION
This patch updates routing url parsing to map the source fragment as the internal URL path, so query strings are handled properly.

It also upgrades a bunch of dependency and fixes the *elm-analyse* errors in skeleton.  

These are mostly breaking changes, so we bump a new 5.0.0 version. 